### PR TITLE
Fix logging and a crash

### DIFF
--- a/wayback.js
+++ b/wayback.js
@@ -7,7 +7,6 @@ module.exports = async function (page, options) {
     let interval = options.interval || 5000
     return new Promise((resolve, reject) => {
         let prevDate;
-        console.log("Saving", page);
         wayback.getClosest(page, function (err, closest) {
             if (err) return console.log(err);
             prevDate = closest.timestamp || "NOTFOUND"

--- a/wayback.js
+++ b/wayback.js
@@ -2,6 +2,7 @@ let request = require('request')
 var wayback = require('wayback-machine');
 
 module.exports = async function (page, options) {
+    options = options || {};
     let max_attempts = (options && options.attempts) || 10
     let interval = options.interval || 5000
     return new Promise((resolve, reject) => {

--- a/wayback.js
+++ b/wayback.js
@@ -8,7 +8,7 @@ module.exports = async function (page, options) {
     return new Promise((resolve, reject) => {
         let prevDate;
         wayback.getClosest(page, function (err, closest) {
-            if (err) return console.log(err);
+            if (err) return reject(err);
             prevDate = closest.timestamp || "NOTFOUND"
             request("http://web.archive.org/save/" + page, function (err, response, body) {
                 if (err != null) throw err;


### PR DESCRIPTION
* Fix a case where instead of rejecting the promise, the library simply logged the error to stdout
* Don't log with `console.log` in the library (the consumer should choose whether they want this behavior or not)
* Fix a crash if the options object wasn't provided at all

The first two changes are semver-major. Thanks for maintaining this library!